### PR TITLE
Token auth, GRUB, private IP, verifySSL and QEMU arch fixes

### DIFF
--- a/nixops_proxmox/backends/options.py
+++ b/nixops_proxmox/backends/options.py
@@ -53,7 +53,7 @@ class ProxmoxOptions(ResourceOptions):
     cpuLimit: Optional[int]
     cpuUnits: Optional[int]
     cpuType: str
-    arch: str
+    arch: Optional[str]
     expertArgs: Optional[str]
 
 

--- a/nixops_proxmox/backends/options.py
+++ b/nixops_proxmox/backends/options.py
@@ -56,6 +56,8 @@ class ProxmoxOptions(ResourceOptions):
     arch: Optional[str]
     expertArgs: Optional[str]
 
+    usePrivateIPAddress: bool
+
 
 class ProxmoxMachineOptions(MachineOptions):
     proxmox: ProxmoxOptions

--- a/nixops_proxmox/backends/proxmox.py
+++ b/nixops_proxmox/backends/proxmox.py
@@ -49,7 +49,7 @@ class VirtualMachineDefinition(MachineDefinition):
                 'cpuLimit', 'cpuUnits', 'cpuType', 'arch',
                 'postPartitioningLocalCommands',
                 'partitions', 'expertArgs', 'installISO', 'network',
-                'uefi', 'useSSH'):
+                'uefi', 'useSSH', 'usePrivateIPAddress'):
             setattr(self, key, getattr(self.config.proxmox, key))
 
         if not self.serverUrl:
@@ -636,6 +636,8 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
         self.tokenValue = defn.tokenValue
 
         self.useSSH = defn.useSSH
+
+        self.use_private_ip_address = defn.usePrivateIPAddress
 
         nodes = self._connect().nodes.get()
         assert len(nodes) == 1, "There is no node or multiple nodes, ensure you set 'deployment.proxmox.node' or verify your Proxmox cluster."

--- a/nixops_proxmox/backends/proxmox.py
+++ b/nixops_proxmox/backends/proxmox.py
@@ -381,7 +381,7 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
             }
         else:
             # Use nix2py to read self.fs_info.
-            nixos_cfg[("boot", "loader", "grub", "devices")] = ""
+            nixos_cfg[("boot", "loader", "grub", "devices")] = [ "/dev/sda" ];
 
         nixos_initial_postinstall_conf = py2nix(Function("{ config, pkgs, ... }", nixos_cfg))
         self.run_command(f"cat <<EOF > /mnt/etc/nixos/configuration.nix\n{nixos_initial_postinstall_conf}\nEOF")

--- a/nixops_proxmox/backends/proxmox.py
+++ b/nixops_proxmox/backends/proxmox.py
@@ -571,7 +571,7 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
             self._allocate_disk_image(filename, disk.size, disk.volume, vmid)
             max_indexes[disk.volume] += 1
 
-        if defn.uefi:
+        if defn.uefi and defn.uefi.enable:
             filename = f'vm-{vmid}-disk-{max_indexes[defn.uefi.volume] + 1}'
             options['efidisk0'] = f'{defn.uefi.volume}:{filename}'
             self._allocate_disk_image(filename,

--- a/nixops_proxmox/backends/proxmox.py
+++ b/nixops_proxmox/backends/proxmox.py
@@ -630,6 +630,9 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
         self.username = defn.username
         self.password = defn.password
 
+        self.tokenName = defn.tokenName
+        self.tokenValue = defn.tokenValue
+
         self.useSSH = defn.useSSH
 
         nodes = self._connect().nodes.get()

--- a/nixops_proxmox/backends/proxmox.py
+++ b/nixops_proxmox/backends/proxmox.py
@@ -515,7 +515,6 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
                 # 'tags': (','.join(tags)),
                 'agent': "enabled=1,type=virtio",
                 'vga': 'qxl',
-                'arch': defn.arch,
                 'args': defn.expertArgs,
                 'bios': ("ovmf" if defn.uefi.enable else "seabios"),
                 'cores': defn.nbCores or 1,
@@ -536,6 +535,9 @@ class VirtualMachineState(MachineState[VirtualMachineDefinition]):
                 'unique': 1,
                 'archive': 0,
         }
+
+        if defn.arch is not None:
+            options[f"arch"] = defn.arch
 
         for index, net in enumerate(defn.network):
             options[f"net{index}"] = (",".join(

--- a/nixops_proxmox/nix/proxmox.nix
+++ b/nixops_proxmox/nix/proxmox.nix
@@ -152,6 +152,13 @@ in
         Whether to verify the SSL certificate of the Proxmox node.
       '';
     };
+    deployment.proxmox.usePrivateIPAddress = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to use the VM private IP address for management.
+      '';
+    };
     deployment.proxmox.useSSH = mkOption {
       default = false;
       type = types.bool;

--- a/nixops_proxmox/nix/proxmox.nix
+++ b/nixops_proxmox/nix/proxmox.nix
@@ -256,9 +256,16 @@ in
       description = "CPU type string";
     };
     deployment.proxmox.arch = mkOption {
-      type = types.str;
-      default = "x86_64";
-      description = "QEMU architecture (supports only aarch64 or x86_64)";
+      type = types.nullOr (types.enum [ "aarch64" "x86_64" ]);
+      default = null;
+      description = ''
+        QEMU architecture.
+
+        The default value will not pass anything in the Proxmox API request.
+        Usage of this option is only permitted to the <literal>root</literal>
+        user by the Proxmox API and only when using username/password
+        authentication.
+      '';
     };
     deployment.proxmox.expertArgs = mkOption {
       type = types.nullOr types.str;

--- a/nixops_proxmox/nix/proxmox.nix
+++ b/nixops_proxmox/nix/proxmox.nix
@@ -145,6 +145,13 @@ in
         It is better to use an API token or SSH authentication!
       '';
     };
+    deployment.proxmox.verifySSL = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to verify the SSL certificate of the Proxmox node.
+      '';
+    };
     deployment.proxmox.useSSH = mkOption {
       default = false;
       type = types.bool;


### PR DESCRIPTION
* Token authentication fix - initialized `tokenName`/`tokenValue` in `VirtualMachineState.create()`.
* GRUB installation fixed - UEFI volume only allocated when `uefi.enable` is `true` and `boot.loader.grub.devices` set to (a hardcoded) `[ "/dev/sda" ]` value.
* Added missing `usePrivateIPAddress` Nix option and initialized the `use_private_ip_address` attribute property accordingly.
* Added missing `verifySSL` Nix option.
* QEMU arch only set in API call if non-null (which defaults the setting to the Proxmox host architecture). The Proxmox API seems to forbid setting this explicitly through token auth (at least that's the claim in the error message).

These have been tested against a Proxmox 6.2-4 instance (`deploy`, `ssh` and `destroy` operations).